### PR TITLE
Limit conversation turn context by bot config

### DIFF
--- a/bot_data/1 - chatbot-davinci-003.yaml
+++ b/bot_data/1 - chatbot-davinci-003.yaml
@@ -2,9 +2,9 @@ id: 1
 name: General Chatbot (davinci-003)
 model: "text-davinci-003"
 temperature: 1
+max_turn_count: 9
+context_turn_count: 9
 prompt: |
   I want to you act as an AI. Your job is to answer my questions. {{.LangHint}}
-  {{- if .WithHistory}}
   Please always give me the answer with prefix "A:".
   {{.History}}
-  {{end}}

--- a/bot_data/2 - chatbot.yaml
+++ b/bot_data/2 - chatbot.yaml
@@ -2,5 +2,7 @@ id: 2
 name: General Chatbot
 model: "gpt-3.5-turbo"
 temperature: 1
+max_turn_count: 9
+context_turn_count: 9
 prompt: |
   I want to you act as an AI. Your job is to answer my questions. {{.LangHint}}

--- a/bot_data/3 - pando-customer-service.yaml
+++ b/bot_data/3 - pando-customer-service.yaml
@@ -2,6 +2,8 @@ id: 3
 name: Pando customer service
 model: "gpt-3.5-turbo"
 temperature: 1
+max_turn_count: 9
+context_turn_count: 1
 middlewares:
   # use the "botastic-search" middleware
   - name: "botastic-search"

--- a/bot_data/4 - searchbot.yaml
+++ b/bot_data/4 - searchbot.yaml
@@ -2,6 +2,8 @@ id: 4
 name: Search Assistant
 model: "gpt-3.5-turbo"
 temperature: 2
+max_turn_count: 9
+context_turn_count: 1
 middlewares:
   - name: "duckduckgo-search"
     options:

--- a/bot_data/5 - vitalik.yaml
+++ b/bot_data/5 - vitalik.yaml
@@ -2,6 +2,8 @@ id: 5
 name: Virtual Vitalik
 model: "gpt-3.5-turbo"
 temperature: 1
+max_turn_count: 9
+context_turn_count: 1
 middlewares:
   # use the "botastic-search" middleware
   - name: "botastic-search"

--- a/core/conv.go
+++ b/core/conv.go
@@ -14,10 +14,6 @@ const (
 	ConvTurnStatusError
 )
 
-const (
-	MaxTurnCount = 8
-)
-
 type (
 	Conversation struct {
 		ID           string      `yaml:"id" json:"id"`
@@ -111,7 +107,11 @@ func (c *Conversation) IsExpired() bool {
 
 func (c *Conversation) HistoryToText() string {
 	lines := make([]string, 0)
-	for _, turn := range c.History {
+	history := c.History
+	if len(history) > c.Bot.ContextTurnCount {
+		history = history[len(history)-c.Bot.ContextTurnCount:]
+	}
+	for _, turn := range history {
 		lines = append(lines, fmt.Sprintf("Q: %s", turn.Request))
 		if turn.Response != "" {
 			lines = append(lines, fmt.Sprintf("A: %s", turn.Response))

--- a/docs/release.md
+++ b/docs/release.md
@@ -60,7 +60,7 @@ networks:
 
 ```
 
-2. Execute the folling command to create the `milvus.yaml` config file.
+2. Execute the following command to create the `milvus.yaml` config file.
 ```shell
 cd milvus
 mkdir -p volumes/milvus_config
@@ -68,7 +68,7 @@ cd volumes/milvus_config
 wget https://raw.githubusercontent.com/milvus-io/milvus/v2.2.3/configs/milvus.yaml
 ```
 
-The `tree` command output as folling,
+The `tree` command output as following,
 ```shell
 cd milvus
 tree

--- a/service/conv/conv.go
+++ b/service/conv/conv.go
@@ -114,12 +114,17 @@ func (s *service) PostToConversation(ctx context.Context, conv *core.Conversatio
 
 	turn := turns[0]
 
-	if len(conv.History) > core.MaxTurnCount {
-		// reduce to MaxTurnCount
-		conv.History = conv.History[len(conv.History)-core.MaxTurnCount:]
+	bot, err := s.botz.GetBot(ctx, conv.Bot.ID)
+	if err != nil {
+		return nil, err
 	}
 
 	conv.History = append(conv.History, turn)
+
+	if len(conv.History) > bot.MaxTurnCount {
+		// reduce to MaxTurnCount
+		conv.History = conv.History[len(conv.History)-bot.MaxTurnCount:]
+	}
 
 	return turn, nil
 }


### PR DESCRIPTION
Close #14 

Add two config options to bots,
* max_turn_count - maximum number of turns in the conversation history
* context_turn_count - how many turns in the conversation history will be applied for chat completion