### PR TITLE
add model store; add support for openai's gpt-4

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,19 @@ An AI framework for building cool things.
 
 ```bash
 curl --location --request POST 'https://botastic-api.pando.im/api/conversations/oneway' \
---header 'X-BOTASTIC-APPID: your botastic app id' \
---header 'X-BOTASTIC-SECRET: your botastic app secret' \
+--header 'X-BOTASTIC-APPID: YOUR_BOTASTIC_APP_ID' \
+--header 'X-BOTASTIC-SECRET: YOUR_BOTASTIC_APP_SECRET' \
 --header 'Content-Type: application/json' \
 --data-raw '{
-  "bot_id": "your bot id",
+  "bot_id": YOUR_BOT_ID,
   "content": "How do you view the future of blockchain, and what benefits does it have for human being? Respond as short as possible like a Zen Master.",
   "category": "plain-text"
 }'
 ```
+
+## Documentation
+
+Please refer to [Guide](https://developers.pando.im/guide/botastic.html) and [API Reference](https://developers.pando.im/references/botastic/api.html) for more details.
 
 ## Showcases
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ An AI framework for building cool things.
 ```bash
 curl --location --request POST 'https://botastic-api.pando.im/api/conversations/oneway' \
 --header 'X-BOTASTIC-APPID: YOUR_BOTASTIC_APP_ID' \
---header 'X-BOTASTIC-SECRET: YOUR_BOTASTIC_APP_SECRET' \
 --header 'Content-Type: application/json' \
 --data-raw '{
   "bot_id": YOUR_BOT_ID,

--- a/cmd/httpd/httpd.go
+++ b/cmd/httpd/httpd.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pandodao/botastic/store/bot"
 	"github.com/pandodao/botastic/store/conv"
 	"github.com/pandodao/botastic/store/index"
+	"github.com/pandodao/botastic/store/model"
 	"github.com/pandodao/botastic/store/order"
 	"github.com/pandodao/botastic/store/user"
 	"github.com/pandodao/botastic/worker"
@@ -85,11 +86,12 @@ func NewCmdHttpd() *cobra.Command {
 				return err
 			}
 			indexes := index.New(ctx, milvusClient)
+			models := model.New()
 
 			userz := userServ.New(userServ.Config{
 				ExtraRate:       cfg.Sys.ExtraRate,
 				InitUserCredits: cfg.Sys.InitUserCredits,
-			}, client, users)
+			}, client, users, models)
 			indexService := indexServ.NewService(ctx, gptHandler, indexes, userz)
 
 			middlewarez := middlewareServ.New(middlewareServ.Config{}, indexService)
@@ -109,7 +111,7 @@ func NewCmdHttpd() *cobra.Command {
 			// httpd's workers
 			workers := []worker.Worker{
 				// rotater
-				rotater.New(rotater.Config{}, gptHandler, convs, apps, convz, botz, middlewarez, userz, hub),
+				rotater.New(rotater.Config{}, gptHandler, convs, apps, models, convz, botz, middlewarez, userz, hub),
 
 				ordersyncer.New(ordersyncer.Config{
 					Interval:       cfg.OrderSyncer.Interval,

--- a/cmd/httpd/httpd.go
+++ b/cmd/httpd/httpd.go
@@ -94,7 +94,7 @@ func NewCmdHttpd() *cobra.Command {
 			}, client, users, models)
 			indexService := indexServ.NewService(ctx, gptHandler, indexes, userz)
 
-			middlewarez := middlewareServ.New(middlewareServ.Config{}, indexService)
+			middlewarez := middlewareServ.New(middlewareServ.Config{}, apps, indexService)
 			botz := botServ.New(botServ.Config{}, apps, bots, middlewarez)
 			convz := convServ.New(convServ.Config{}, convs, botz)
 			orderz := orderServ.New(orderServ.Config{

--- a/core/bot.go
+++ b/core/bot.go
@@ -11,7 +11,7 @@ import (
 	"text/template"
 	"time"
 
-	gogpt "github.com/sashabaranov/go-gpt3"
+	gogpt "github.com/sashabaranov/go-openai"
 )
 
 type JSONB json.RawMessage

--- a/core/middleware.go
+++ b/core/middleware.go
@@ -20,7 +20,6 @@ const (
 
 type (
 	Middleware struct {
-		ID      uint64            `yaml:"id" json:"id"`
 		Name    string            `yaml:"name" json:"name"`
 		Options MiddlewareOptions `yaml:"options" json:"options"`
 	}

--- a/core/model.go
+++ b/core/model.go
@@ -1,0 +1,52 @@
+package core
+
+import (
+	"context"
+
+	"github.com/shopspring/decimal"
+)
+
+const (
+	ModelProviderOpenAI = "openai"
+)
+
+const (
+	ModelOpenAIGPT4               = "openai:gpt-4"
+	ModelOpenAIGPT3Dot5Turbo      = "openai:gpt-3.5-turbo"
+	ModelOpenAIGPT3TextDavinci003 = "openai:text-davinci-003"
+	ModelOpenAIAdaEmbeddingV2     = "openai:text-embedding-ada-002"
+)
+
+type (
+	Model struct {
+		Provider           string          `yaml:"provider"`
+		ProviderModel      string          `yaml:"provider_model"`
+		MaxToken           int             `yaml:"max_token"`
+		PromptPriceUSD     decimal.Decimal `yaml:"prompt_price_usd"`
+		CompletionPriceUSD decimal.Decimal `yaml:"completion_price_usd"`
+		PriceUSD           decimal.Decimal `yaml:"price_usd"`
+
+		Props struct {
+			IsOpenAIChatModel       bool `yaml:"is_openai_chat_model"`
+			IsOpenAICompletionModel bool `yaml:"is_openai_completion_model"`
+			IsOpenAIEmbeddingModel  bool `yaml:"is_openai_embedding_model"`
+		}
+	}
+
+	ModelStore interface {
+		GetModel(ctx context.Context, name string) (*Model, error)
+	}
+)
+
+func (m *Model) CalculateTokenCost(promptCount, completionCount int64) decimal.Decimal {
+	pc := decimal.NewFromInt(promptCount)
+	cc := decimal.NewFromInt(completionCount)
+
+	if m.PriceUSD.IsPositive() {
+		return m.PriceUSD.Mul(pc.Add(cc))
+	}
+	if m.PromptPriceUSD.IsPositive() && m.CompletionPriceUSD.IsPositive() {
+		return m.PromptPriceUSD.Mul(pc).Add(m.CompletionPriceUSD.Mul(cc))
+	}
+	return decimal.Zero
+}

--- a/core/user.go
+++ b/core/user.go
@@ -89,7 +89,8 @@ type (
 		LoginWithMixin(ctx context.Context, token, pubkey, lang string) (*User, error)
 		Topup(ctx context.Context, user *User, amount decimal.Decimal) error
 		ConsumeCredits(ctx context.Context, userID uint64, amount decimal.Decimal) error
-		ConsumeCreditsByModel(ctx context.Context, userID uint64, model string, amount uint64) error
+		// ConsumeCreditsByModel(ctx context.Context, userID uint64, model string, amount uint64) error
+		ConsumeCreditsByModel(ctx context.Context, userID uint64, model string, promptTokenCount, completionTokenCount int64) error
 		ReplaceStore(store UserStore) UserService
 	}
 )

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/pandodao/tokenizer-go v0.0.1
 	github.com/pressly/goose/v3 v3.9.0
 	github.com/rs/cors v1.8.3
-	github.com/sashabaranov/go-gpt3 v1.3.3
+	github.com/sashabaranov/go-openai v1.5.7
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	golang.org/x/sync v0.1.0
@@ -91,7 +91,7 @@ require (
 	github.com/go-playground/validator/v10 v10.11.1 // indirect
 	github.com/go-sql-driver/mysql v1.7.0 // indirect
 	github.com/goccy/go-json v0.9.11 // indirect
-	github.com/gofrs/uuid v4.4.0+incompatible // indirect
+	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -519,8 +519,8 @@ github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThC
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
-github.com/sashabaranov/go-gpt3 v1.3.3 h1:S8Zd4YybnBaNMK+w+XGGWgsjQY1R+6QE2n9SLzVna9k=
-github.com/sashabaranov/go-gpt3 v1.3.3/go.mod h1:BIZdbwdzxZbCrcKGMGH6u2eyGe1xFuX9Anmh3tCP8lQ=
+github.com/sashabaranov/go-openai v1.5.7 h1:8DGgRG+P7yWixte5j720y6yiXgY3Hlgcd0gcpHdltfo=
+github.com/sashabaranov/go-openai v1.5.7/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/schollz/closestmatch v2.1.0+incompatible/go.mod h1:RtP1ddjLong6gTkbtmuhtR2uUrrJOpYzYRvbcPAid+g=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=

--- a/internal/gpt/gpt.go
+++ b/internal/gpt/gpt.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/fox-one/pkg/logger"
-	gogpt "github.com/sashabaranov/go-gpt3"
+	gogpt "github.com/sashabaranov/go-openai"
 )
 
 var ErrTooManyRequests = errors.New("too many requests")

--- a/service/index/index.go
+++ b/service/index/index.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pandodao/botastic/internal/milvus"
 	"github.com/pandodao/botastic/session"
 	"github.com/pandodao/tokenizer-go"
-	gogpt "github.com/sashabaranov/go-gpt3"
+	gogpt "github.com/sashabaranov/go-openai"
 )
 
 func NewService(ctx context.Context, gptHandler *gpt.Handler, indexes core.IndexStore, userz core.UserService) core.IndexService {
@@ -39,7 +39,7 @@ func (s *serviceImpl) createEmbeddingsWithLimit(ctx context.Context, req gogpt.E
 
 	resp, err := s.gptHandler.CreateEmbeddings(ctx, req)
 	if err == nil {
-		if err := s.userz.ConsumeCreditsByModel(ctx, userID, gogpt.AdaEmbeddingV2.String(), uint64(resp.Usage.TotalTokens)); err != nil {
+		if err := s.userz.ConsumeCreditsByModel(ctx, userID, gogpt.AdaEmbeddingV2.String(), int64(resp.Usage.PromptTokens), int64(resp.Usage.CompletionTokens)); err != nil {
 			log.Printf("ConsumeCredits error: %v\n", err)
 		}
 	}

--- a/service/middleware/middleware.go
+++ b/service/middleware/middleware.go
@@ -17,11 +17,9 @@ func New(
 ) *service {
 	middlewareMap := make(map[string]*core.Middleware)
 	middlewareMap["botastic-search"] = &core.Middleware{
-		ID:   1,
 		Name: "botastic-search",
 	}
 	middlewareMap["duckduckgo-search"] = &core.Middleware{
-		ID:   2,
 		Name: "duckduckgo-search",
 	}
 	return &service{

--- a/store/model/model.go
+++ b/store/model/model.go
@@ -1,0 +1,68 @@
+package model
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"github.com/pandodao/botastic/core"
+	"gopkg.in/yaml.v2"
+)
+
+type (
+	store struct {
+		modelMap map[string]*core.Model
+	}
+)
+
+//go:embed models.yaml
+var modelsConfig string
+
+func New() *store {
+	modelMap, err := LoadModels()
+	if err != nil {
+		panic(err)
+	}
+	return &store{
+		modelMap: modelMap,
+	}
+}
+
+func LoadModels() (map[string]*core.Model, error) {
+	models := []*core.Model{}
+	modelMap := make(map[string]*core.Model)
+
+	if err := yaml.Unmarshal([]byte(modelsConfig), &models); err != nil {
+		return nil, err
+	}
+
+	for _, m := range models {
+		key := fmt.Sprintf("%s:%s", m.Provider, m.ProviderModel)
+		modelMap[key] = m
+
+		if m.Provider == core.ModelProviderOpenAI {
+			switch m.ProviderModel {
+			case "gpt-4", "gpt-4-32k", "gpt-4-0314", "gpt-4-32k-0314", "gpt-3.5-turbo", "gpt-3.5-turbo-0301":
+				m.Props.IsOpenAIChatModel = true
+			case "text-davinci-003":
+				m.Props.IsOpenAICompletionModel = true
+			case "text-embedding-ada-002":
+				m.Props.IsOpenAIEmbeddingModel = true
+			}
+		}
+
+		// backward compatibility
+		if m.Provider == core.ModelProviderOpenAI {
+			modelMap[m.ProviderModel] = m
+		}
+	}
+
+	return modelMap, nil
+}
+
+func (s *store) GetModel(ctx context.Context, name string) (*core.Model, error) {
+	if model, ok := s.modelMap[name]; ok {
+		return model, nil
+	}
+	return nil, core.ErrInvalidModel
+}

--- a/store/model/models.yaml
+++ b/store/model/models.yaml
@@ -33,4 +33,4 @@
 - provider: openai
   provider_model: text-embedding-ada-002
   price_usd: 0.0000004 # 0.0004 per 1000 tokens
-  max_token: 2049
+  max_token: 8191

--- a/store/model/models.yaml
+++ b/store/model/models.yaml
@@ -1,0 +1,36 @@
+- provider: openai
+  provider_model: gpt-4
+  prompt_price_usd: 0.00003 # $0.03 / 1K tokens
+  completion_price_usd: 0.00006 # $0.06 / 1K tokens
+  max_token: 8192
+- provider: openai
+  provider_model: gpt-4-0314
+  prompt_price_usd: 0.00003 # $0.03 / 1K tokens
+  completion_price_usd: 0.00006 # $0.06 / 1K tokens
+  max_token: 8192
+- provider: openai
+  provider_model: gpt-4-32k
+  prompt_price_usd: 0.00006 # $0.06 / 1K tokens
+  completion_price_usd: 0.00012 # $0.12 / 1K tokens
+  max_token: 32768
+- provider: openai
+  provider_model: gpt-4-32k-0314
+  prompt_price_usd: 0.00006 # $0.06 / 1K tokens
+  completion_price_usd: 0.00012 # $0.12 / 1K tokens
+  max_token: 32768
+- provider: openai
+  provider_model: gpt-3.5-turbo
+  price_usd: 0.000002 # $0.002 per 1000 tokens
+  max_token: 4096
+- provider: openai
+  provider_model: gpt-3.5-turbo-0301
+  price_usd: 0.000002 # $0.002 per 1000 tokens
+  max_token: 4096
+- provider: openai
+  provider_model: text-davinci-003
+  price_usd: 0.00002 # $0.02 per 1000 tokens
+  max_token: 4097
+- provider: openai
+  provider_model: text-embedding-ada-002
+  price_usd: 0.0000004 # 0.0004 per 1000 tokens
+  max_token: 2049


### PR DESCRIPTION
Using `store/model/models.yaml` to declare all supported models.

Model price and max token are included.

Add GPT-4 support