### PR TITLE
Add middleware interface and reorg middleware

### DIFF
--- a/core/bot.go
+++ b/core/bot.go
@@ -20,10 +20,12 @@ const (
 	MiddlewareIntentRecognition = "intent-recognition"
 )
 
-const MiddlewareProcessCodeUnknown = -1
-
 const (
 	MiddlewareProcessCodeOK = iota
+	MiddlewareProcessCodeUnknown
+	MiddlewareProcessCodeInvalidOptions
+	MiddlewareProcessCodeInternalError
+	MiddlewareProcessCodeTimeout
 )
 
 type (
@@ -37,15 +39,23 @@ type (
 	}
 
 	MiddlewareProcessResult struct {
+		Opts   any    `json:"opts,omitempty"`
 		Name   string `json:"name"`
-		Code   uint64 `json:"code"`
-		Result string `json:"result"`
+		Code   int    `json:"code"`
+		Result string `json:"result,omitempty"`
+		Err    error  `json:"err,omitempty"`
+		Break  bool   `json:"break,omitempty"`
 	}
 
 	MiddlewareService interface {
-		Process(ctx context.Context, m *Middleware, input string) (*MiddlewareProcessResult, error)
+		ProcessByConfig(ctx context.Context, m MiddlewareConfig, input string) []*MiddlewareProcessResult
+		Process(ctx context.Context, m *Middleware, input string) *MiddlewareProcessResult
 	}
 )
+
+func (m Middleware) GetName() string {
+	return m.Name
+}
 
 func (a MiddlewareConfig) Value() (driver.Value, error) {
 	return json.Marshal(a)

--- a/service/middleware/botastic_search.go
+++ b/service/middleware/botastic_search.go
@@ -83,5 +83,5 @@ func (m *botasticSearch) Process(ctx context.Context, opts any, input string) (s
 		}
 	}
 
-	return fmt.Sprintf("[context-begin]\n%s\n[context-end]\n", strings.Join(arr, "\n")), nil
+	return strings.Join(arr, "\n"), nil
 }

--- a/service/middleware/botastic_search.go
+++ b/service/middleware/botastic_search.go
@@ -1,0 +1,87 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/pandodao/botastic/core"
+	"github.com/pandodao/botastic/session"
+)
+
+type botasticSearch struct {
+	apps   core.AppStore
+	indexz core.IndexService
+}
+
+type botasticSearchOptions struct {
+	*generalOptions
+	Limit int    `json:"limit"`
+	AppID string `json:"app_id"`
+}
+
+func (m *botasticSearch) Name() string {
+	return core.MiddlewareBotasticSearch
+}
+
+func (m *botasticSearch) ValidateOptions(gopts *generalOptions, opts map[string]any) (any, error) {
+	options := &botasticSearchOptions{
+		generalOptions: gopts,
+		Limit:          3,
+	}
+
+	if val, ok := opts["limit"]; ok {
+		v, ok := val.(float64)
+		if !ok {
+			return nil, fmt.Errorf("limit is not a number: %v", val)
+		}
+
+		if v <= 0 || float64(int(v)) != v {
+			return nil, fmt.Errorf("limit is not a positive integer: %v", v)
+		}
+		options.Limit = int(v)
+	}
+
+	if val, ok := opts["app_id"]; ok {
+		appID, ok := val.(string)
+		if !ok {
+			return nil, fmt.Errorf("app_id must be a string: %v", val)
+		}
+
+		options.AppID = appID
+	}
+
+	return options, nil
+}
+
+func (m *botasticSearch) Process(ctx context.Context, opts any, input string) (string, error) {
+	options := opts.(*botasticSearchOptions)
+	app := session.AppFrom(ctx)
+	if options.AppID != "" {
+		optionsApp, err := m.apps.GetAppByAppID(ctx, options.AppID)
+		if err != nil {
+			return "", fmt.Errorf("error when getting app by app_id: %s", optionsApp.AppID)
+		}
+		if optionsApp.UserID != app.UserID {
+			return "", fmt.Errorf("app_id not found: %s", options.AppID)
+		}
+		app = optionsApp
+		ctx = session.WithApp(ctx, app)
+	}
+
+	searchResult, err := m.indexz.SearchIndex(ctx, app.UserID, input, options.Limit)
+	if err != nil {
+		return "", err
+	}
+
+	arr := make([]string, 0)
+	for ix, r := range searchResult {
+		line := strings.ReplaceAll(strings.ReplaceAll(r.Data, "\n", " "), "\r", "")
+		line = strings.TrimSpace(line)
+		if line != "" {
+			arr = append(arr, fmt.Sprintf("%d: %s\n", ix+1, line))
+		}
+	}
+
+	return fmt.Sprintf("[context-begin]\n%s\n[context-end]\n", strings.Join(arr, "\n")), nil
+}

--- a/service/middleware/ddg_search.go
+++ b/service/middleware/ddg_search.go
@@ -1,0 +1,54 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pandodao/botastic/core"
+	"github.com/pandodao/botastic/internal/ddg"
+)
+
+type duckDuckGoSearch struct{}
+
+func (m *duckDuckGoSearch) Name() string {
+	return core.MiddlewareDuckduckgoSearch
+}
+
+type duckDuckGoSearchOptions struct {
+	*generalOptions
+	Limit int `json:"limit"`
+}
+
+func (m *duckDuckGoSearch) ValidateOptions(gopts *generalOptions, opts map[string]any) (any, error) {
+	options := &duckDuckGoSearchOptions{
+		generalOptions: gopts,
+		Limit:          3,
+	}
+
+	if val, ok := opts["limit"]; ok {
+		v, ok := val.(float64)
+		if !ok {
+			return nil, fmt.Errorf("limit is not a number: %v", val)
+		}
+
+		if v <= 0 || float64(int(v)) != v {
+			return nil, fmt.Errorf("limit is not a positive integer: %v", v)
+		}
+		options.Limit = int(v)
+	}
+
+	return options, nil
+}
+
+func (m *duckDuckGoSearch) Process(ctx context.Context, opts any, input string) (string, error) {
+	options := opts.(*duckDuckGoSearchOptions)
+	r, err := ddg.WebSearch(ctx, input, options.Limit)
+	if err != nil {
+		return "", err
+	}
+	result, err := r.Text()
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}

--- a/service/middleware/intent_recognition.go
+++ b/service/middleware/intent_recognition.go
@@ -1,0 +1,57 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/pandodao/botastic/core"
+)
+
+type intentRecognition struct{}
+
+type intentRecognitionOptions struct {
+	*generalOptions
+	Intents []string `json:"intents"`
+}
+
+func (m *intentRecognition) Name() string {
+	return core.MiddlewareIntentRecognition
+}
+
+func (m *intentRecognition) ValidateOptions(gopts *generalOptions, opts map[string]any) (any, error) {
+	options := &intentRecognitionOptions{
+		generalOptions: gopts,
+	}
+
+	val, ok := opts["intents"]
+	if ok {
+		_val, ok := val.([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("intents should be an array: %v", val)
+		}
+		for _, v := range _val {
+			intent, ok := v.(string)
+			if !ok {
+				return nil, fmt.Errorf("intents should be an array of string: %v", v)
+			}
+			options.Intents = append(options.Intents, intent)
+		}
+	}
+
+	return options, nil
+}
+
+func (m *intentRecognition) Process(ctx context.Context, opts any, input string) (string, error) {
+	options := opts.(*intentRecognitionOptions)
+
+	prompt := `You will analyze the intent of the request.
+You will output the analyze result at the beginning of your response as json format: {"intent": Here is your intent analyze result}
+The possible intents should be one of following. If you have no confident about the intent, please use "unknown intent":`
+
+	if len(options.Intents) == 0 {
+		return "", nil
+	}
+
+	return fmt.Sprintf("%s\n\n[intents-begin]\n%s\n[intents-end]\n", prompt, strings.Join(options.Intents, "\n")), nil
+}

--- a/service/middleware/intent_recognition.go
+++ b/service/middleware/intent_recognition.go
@@ -53,5 +53,5 @@ The possible intents should be one of following. If you have no confident about 
 		return "", nil
 	}
 
-	return fmt.Sprintf("%s\n\n[intents-begin]\n%s\n[intents-end]\n", prompt, strings.Join(options.Intents, "\n")), nil
+	return fmt.Sprintf("%s\n%s", prompt, strings.Join(options.Intents, "\n")), nil
 }

--- a/service/middleware/middleware.go
+++ b/service/middleware/middleware.go
@@ -2,31 +2,46 @@ package middleware
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"strings"
+	"time"
 
 	"github.com/pandodao/botastic/core"
-	"github.com/pandodao/botastic/internal/ddg"
-	"github.com/pandodao/botastic/session"
 )
+
+type Middleware interface {
+	Name() string
+	ValidateOptions(gopts *generalOptions, opts map[string]any) (any, error)
+	Process(ctx context.Context, opts any, input string) (string, error)
+}
+
+type generalOptions struct {
+	Break   bool          `json:"break"`
+	Timeout time.Duration `json:"timeout"`
+}
 
 func New(
 	cfg Config,
 	apps core.AppStore,
 	indexz core.IndexService,
 ) *service {
-	middlewareMap := make(map[string]*core.Middleware)
-	middlewareMap["botastic-search"] = &core.Middleware{
-		Name: "botastic-search",
-	}
-	middlewareMap["duckduckgo-search"] = &core.Middleware{
-		Name: "duckduckgo-search",
-	}
-	return &service{
-		cfg:    cfg,
-		apps:   apps,
-		indexz: indexz,
 
+	middlewareMap := map[string]Middleware{}
+	for _, m := range []Middleware{
+		&botasticSearch{
+			apps:   apps,
+			indexz: indexz,
+		},
+		&duckDuckGoSearch{},
+		&intentRecognition{},
+	} {
+		middlewareMap[m.Name()] = m
+	}
+
+	return &service{
+		cfg:           cfg,
+		apps:          apps,
+		indexz:        indexz,
 		middlewareMap: middlewareMap,
 	}
 }
@@ -40,118 +55,104 @@ type (
 		apps   core.AppStore
 		indexz core.IndexService
 
-		middlewareMap map[string]*core.Middleware
+		middlewareMap map[string]Middleware
 	}
 )
 
-func (s *service) GetMiddlewareByName(ctx context.Context, name string) (*core.Middleware, error) {
-	middleware, found := s.middlewareMap[name]
-	if !found {
-		return nil, core.ErrMiddlewareNotFound
-	}
-	return middleware, nil
-}
-
-func (s *service) ProcessIntentRecognition(ctx context.Context, m *core.Middleware, input string) (*core.MiddlewareProcessResult, error) {
-	prompt := `You will analyze the intent of the request.
-You will output the analyze result at the beginning of your response as json format: {"intent": Here is your intent analyze result}
-The possible intents should be one of following. If you have no confident about the intent, please use "unknown intent":`
-
-	var intents []string
-	val, ok := m.Options["intents"]
-	if ok {
-		_val, ok := val.([]interface{})
-		if ok {
-			for _, v := range _val {
-				str, ok := v.(string)
-				if !ok {
-					continue
-				}
-				intents = append(intents, str)
-			}
+func (s *service) ProcessByConfig(ctx context.Context, mc core.MiddlewareConfig, input string) []*core.MiddlewareProcessResult {
+	var results []*core.MiddlewareProcessResult
+	for _, m := range mc.Items {
+		result := s.Process(ctx, m, input)
+		results = append(results, result)
+		if result.Break {
+			break
 		}
-	} else {
-		return nil, nil
 	}
-
-	ret := &core.MiddlewareProcessResult{
-		Name:   m.Name,
-		Code:   core.MiddlewareProcessCodeOK,
-		Result: fmt.Sprintf("%s\n\n[intents-begin]\n%s\n[intents-end]\n", prompt, strings.Join(intents, "\n")),
-	}
-	return ret, nil
+	return results
 }
 
-func (s *service) ProcessBotasticSearch(ctx context.Context, m *core.Middleware, input string) (*core.MiddlewareProcessResult, error) {
-	limit := 3
-	app := session.AppFrom(ctx)
-
-	val, ok := m.Options["limit"]
-	if ok {
-		limit = int(val.(float64))
-	}
-
-	val, ok = m.Options["app_id"]
-	if ok {
-		appID := string(val.(string))
-		givingApp, err := s.apps.GetAppByAppID(ctx, appID)
-		if err == nil {
-			app = givingApp
+func (s *service) Process(ctx context.Context, m *core.Middleware, input string) *core.MiddlewareProcessResult {
+	gopts, err := parseGeneralOptions(ctx, m.Options)
+	if err != nil {
+		return &core.MiddlewareProcessResult{
+			Name:  m.Name,
+			Code:  core.MiddlewareProcessCodeInvalidOptions,
+			Err:   err,
+			Break: true,
 		}
 	}
 
-	searchResult, err := s.indexz.SearchIndex(ctx, app.UserID, input, limit)
-	if err != nil {
-		return nil, err
-	}
-
-	arr := make([]string, 0)
-	for ix, r := range searchResult {
-		line := strings.ReplaceAll(strings.ReplaceAll(r.Data, "\n", " "), "\r", "")
-		line = strings.TrimSpace(line)
-		if line != "" {
-			arr = append(arr, fmt.Sprintf("%d: %s\n", ix+1, line))
+	middleware := s.middlewareMap[m.Name]
+	if middleware == nil {
+		return &core.MiddlewareProcessResult{
+			Name:  m.Name,
+			Code:  core.MiddlewareProcessCodeUnknown,
+			Err:   errors.New("middleware not found"),
+			Break: gopts.Break,
 		}
 	}
 
-	ret := &core.MiddlewareProcessResult{
-		Name:   m.Name,
-		Code:   core.MiddlewareProcessCodeOK,
-		Result: fmt.Sprintf("[context-begin]\n%s\n[context-end]\n", strings.Join(arr, "\n")),
+	opts, err := middleware.ValidateOptions(gopts, m.Options)
+	if err != nil {
+		return &core.MiddlewareProcessResult{
+			Name:  m.Name,
+			Code:  core.MiddlewareProcessCodeInvalidOptions,
+			Err:   err,
+			Break: gopts.Break,
+		}
 	}
-	return ret, nil
-}
 
-func (s *service) ProcessDuckduckgoSearch(ctx context.Context, m *core.Middleware, input string) (*core.MiddlewareProcessResult, error) {
-	limit := 3
-	val, ok := m.Options["limit"]
-	if ok {
-		limit = int(val.(float64))
+	if gopts.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, gopts.Timeout)
+		defer cancel()
 	}
-	r, err := ddg.WebSearch(ctx, input, limit)
+
+	result, err := middleware.Process(ctx, opts, input)
 	if err != nil {
-		return nil, err
+		code := core.MiddlewareProcessCodeInternalError
+		if errors.Is(err, context.DeadlineExceeded) {
+			code = core.MiddlewareProcessCodeTimeout
+		}
+
+		return &core.MiddlewareProcessResult{
+			Name:  m.Name,
+			Code:  code,
+			Err:   err,
+			Break: gopts.Break,
+		}
 	}
-	result, err := r.Text()
-	if err != nil {
-		return nil, err
-	}
-	ret := &core.MiddlewareProcessResult{
+
+	return &core.MiddlewareProcessResult{
+		Opts:   opts,
 		Name:   m.Name,
 		Code:   core.MiddlewareProcessCodeOK,
 		Result: result,
 	}
-	return ret, nil
 }
 
-func (s *service) Process(ctx context.Context, m *core.Middleware, input string) (*core.MiddlewareProcessResult, error) {
-	switch m.Name {
-	case core.MiddlewareBotasticSearch:
-		return s.ProcessBotasticSearch(ctx, m, input)
-	case core.MiddlewareDuckduckgoSearch:
-		return s.ProcessDuckduckgoSearch(ctx, m, input)
-	case core.MiddlewareIntentRecognition:
-		return s.ProcessIntentRecognition(ctx, m, input)
+func parseGeneralOptions(ctx context.Context, opts map[string]any) (*generalOptions, error) {
+	generalOptions := &generalOptions{}
+
+	if val, ok := opts["break"]; ok {
+		b, ok := val.(bool)
+		if !ok {
+			return nil, fmt.Errorf("break should be bool: %v", val)
+		}
+		generalOptions.Break = b
 	}
-	return nil, nil
+
+	if val, ok := opts["timeout"]; ok {
+		s, ok := val.(string)
+		if !ok {
+			return nil, fmt.Errorf("timeout should be string: %v", val)
+		}
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			return nil, fmt.Errorf("timeout should be valid duration: %v", val)
+		}
+		generalOptions.Timeout = d
+	}
+
+	return generalOptions, nil
 }


### PR DESCRIPTION
Close #39 

---

* Add middleware general options: `break` and `timeout`.
* Set placeholders for each middleware, `MiddlewareOutput_+strings.ToUpper(strings.ReplaceAll(middleware.Name, "-", "_"))` (eg. `botastic-search` =>`MiddlewareOutput_BOTASTIC_SEARCH`)