### PR TITLE
Support to run in local mode

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	jsoniter "github.com/json-iterator/go"
 	"github.com/pandodao/botastic/cmd/app"
 	"github.com/pandodao/botastic/cmd/gen"
 	"github.com/pandodao/botastic/cmd/httpd"
@@ -14,7 +13,6 @@ import (
 	"github.com/pandodao/botastic/config"
 	"github.com/pandodao/botastic/session"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var opt struct {
@@ -30,28 +28,16 @@ func NewCmdRoot(version string) *cobra.Command {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			s := session.From(cmd.Context())
 
-			v := viper.New()
-			v.SetConfigType("yaml")
-
 			if opt.KeystoreFile != "" {
-				f, err := os.Open(opt.KeystoreFile)
+				data, err := os.ReadFile(opt.KeystoreFile)
 				if err != nil {
-					return fmt.Errorf("open keystore file %s failed: %w", opt.KeystoreFile, err)
+					return fmt.Errorf("read keystore file %s failed: %w", opt.KeystoreFile, err)
 				}
-
-				defer f.Close()
-				_ = v.ReadConfig(f)
-			}
-
-			if values := v.AllSettings(); len(values) > 0 {
-				b, _ := jsoniter.Marshal(values)
-				keystore, pin, err := cmdutil.DecodeKeystore(b)
+				keystore, pin, err := cmdutil.DecodeKeystore(data)
 				if err != nil {
 					return fmt.Errorf("decode keystore failed: %w", err)
 				}
-
 				s.WithKeystore(keystore)
-
 				if pin != "" {
 					s.WithPin(pin)
 				}

--- a/cmdutil/store.go
+++ b/cmdutil/store.go
@@ -3,12 +3,8 @@ package cmdutil
 import (
 	"encoding/json"
 	"fmt"
-	"path"
 
 	"github.com/fox-one/mixin-sdk-go"
-	jsoniter "github.com/json-iterator/go"
-	"github.com/mitchellh/go-homedir"
-	"github.com/spf13/viper"
 )
 
 type Keystore struct {
@@ -23,28 +19,4 @@ func DecodeKeystore(b []byte) (*mixin.Keystore, string, error) {
 	}
 
 	return store.Keystore, store.Pin, nil
-}
-
-func (store *Keystore) String() string {
-	b, _ := json.MarshalIndent(store, "", "  ")
-	return string(b)
-}
-
-func LookupAndLoadKeystore(name string) ([]byte, error) {
-	home, err := homedir.Dir()
-	if err != nil {
-		return nil, err
-	}
-
-	v := viper.New()
-	v.SetConfigName(name)
-	v.SetConfigType("json")
-	v.SetConfigType("yaml")
-	v.AddConfigPath(path.Join(home, ".mixin-cli"))
-
-	if err := v.ReadInConfig(); err != nil {
-		return nil, err
-	}
-
-	return jsoniter.Marshal(v.AllSettings())
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -8,9 +8,43 @@ openai:
 
 sys:
   secret_key: ""
-  init_user_credits: 0.1
-  app_per_user_limit: 10
-  bot_per_user_limit: 10
+  mode: local # cloud
+  local:
+  cloud:
+    init_user_credits: 0.1
+    app_per_user_limit: 10
+    bot_per_user_limit: 10
+    mixpay:
+      payee_id: "USER_UUID"
+      quote_asset_id: "31d2ea9c-95eb-3355-b65b-ba096853bc18"
+      settlement_asset_id: "31d2ea9c-95eb-3355-b65b-ba096853bc18"
+      callback_url: "$API_HOST/api/callback/mixpay"
+      return_to: ""
+      failed_return_to: ""
+    lemonsqueezy:
+      key: ""
+      store_id: 12345
+    topup_variants:
+      - name: "$1.00"
+        amount: 1.00
+      - name: "$5.00"
+        amount: 5.00
+      - name: "$10.00"
+        amount: 10.00
+        lemon_id: 123456
+    twitter:
+      api_key: ""
+      api_secret: ""
+      callback_url: "https://"
+    order_syncer:
+      interval: 1s
+      check_interval: 10s
+      cancel_interval: 2h
+    auth:
+      jwt_secret: "abc123"
+      mixin_client_secret: "...."
+      trust_domains:
+        - "developers.pando.im"
 
 index_store:
   driver: memory # redis, milvus
@@ -23,40 +57,3 @@ index_store:
     address: "localhost:19530"
     collection: indexes
     collection_shards_num: 2
-
-mixpay:
-  payee_id: "USER_UUID"
-  quote_asset_id: "31d2ea9c-95eb-3355-b65b-ba096853bc18"
-  settlement_asset_id: "31d2ea9c-95eb-3355-b65b-ba096853bc18"
-  callback_url: "$API_HOST/api/callback/mixpay"
-  return_to: ""
-  failed_return_to: ""
-
-lemonsqueezy:
-  key: ""
-  store_id: 12345
-
-topup_variants:
-  - name: "$1.00"
-    amount: 1.00
-  - name: "$5.00"
-    amount: 5.00
-  - name: "$10.00"
-    amount: 10.00
-    lemon_id: 123456
-
-twitter:
-  api_key: ""
-  api_secret: ""
-  callback_url: "https://"
-
-order_syncer:
-  interval: 1s
-  check_interval: 10s
-  cancel_interval: 2h
-
-auth:
-  jwt_secret: "abc123"
-  mixin_client_secret: "...."
-  trust_domains:
-    - "developers.pando.im"

--- a/handler/auth/auth.go
+++ b/handler/auth/auth.go
@@ -135,13 +135,13 @@ func GetTwitterURL(twitterClient *twitter.Client, callbackURL string) http.Handl
 	}
 }
 
-func HandleAuthentication(s *session.Session, users core.UserStore, mode config.SystemMode) func(http.Handler) http.Handler {
+func HandleAuthentication(s *session.Session, users core.UserStore, mode config.Mode) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
 
 			var userID uint64
-			if mode == config.SystemModeCloud {
+			if mode == config.ModeSaaS {
 				accessToken := getBearerToken(r)
 				if accessToken == "" {
 					next.ServeHTTP(w, r)
@@ -278,10 +278,10 @@ func LoginRequired() func(http.Handler) http.Handler {
 	}
 }
 
-func UserCreditRequired(users core.UserStore, mode config.SystemMode) func(http.Handler) http.Handler {
+func UserCreditRequired(users core.UserStore, mode config.Mode) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
-			if mode == config.SystemModeLocal {
+			if mode == config.ModeLocal {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/handler/serve.go
+++ b/handler/serve.go
@@ -57,7 +57,7 @@ func New(cfg Config, s *session.Session,
 
 type (
 	Config struct {
-		Mode               config.SystemMode
+		Mode               config.Mode
 		ClientID           string
 		TrustDomains       []string
 		Lemon              config.Lemonsqueezy
@@ -145,7 +145,7 @@ func (s Server) HandleRest() http.Handler {
 		r.Delete("/{appID}", app.DeleteApp(s.appz))
 	})
 
-	if s.cfg.Mode == config.SystemModeCloud {
+	if s.cfg.Mode == config.ModeSaaS {
 		r.Route("/auth", func(r chi.Router) {
 			r.Post("/login", auth.Login(s.session, s.userz, s.cfg.ClientID, s.cfg.TrustDomains))
 			r.Get("/twitter/url", auth.GetTwitterURL(s.twitterClient, s.cfg.TwitterCallbackUrl))

--- a/store/user/local.go
+++ b/store/user/local.go
@@ -1,0 +1,27 @@
+package user
+
+import (
+	"context"
+
+	"github.com/pandodao/botastic/core"
+	"github.com/shopspring/decimal"
+)
+
+type localModeStore struct {
+	core.UserStore
+	user *core.User
+}
+
+func NewLocalModeStore(user *core.User) *localModeStore {
+	return &localModeStore{
+		user: user,
+	}
+}
+
+func (s *localModeStore) GetUser(ctx context.Context, id uint64) (*core.User, error) {
+	return s.user, nil
+}
+
+func (s *localModeStore) UpdateCredits(ctx context.Context, id uint64, amount decimal.Decimal) error {
+	return nil
+}


### PR DESCRIPTION
The purpose of this PR is to make local deployment easy. Currently, it is difficult to deploy it locally; some middlewares block our requests (eg. login check, user credit check), and some configurations are not required (eg. mixpay, twitter). We should skip these checks if we deploy locally. 


---

* Add a new config option called `mode` to `sys` layer,
  * If it is set to `cloud`, everything runs as before.
  * if it is set to `local`, then we'll use `localModeStore` to replace `userStore`, for `GetUser` call, it always returns `&User{ID: 0}`. Of course, middlewares will skip checks in local mode.
* Reorg configuration in this PR, split most configurations into two groups: sys.local / sys.cloud, and then depending on the mode we can clearly know which configuration is required. (see the config.example.yaml diff in this PR)