### PR TITLE
Remove extra_rate config

### DIFF
--- a/cmd/httpd/httpd.go
+++ b/cmd/httpd/httpd.go
@@ -93,7 +93,6 @@ func NewCmdHttpd() *cobra.Command {
 			}
 
 			userz := userServ.New(userServ.Config{
-				ExtraRate:       cfg.Sys.ExtraRate,
 				InitUserCredits: cfg.Sys.InitUserCredits,
 			}, client, users)
 			indexService := indexServ.NewService(ctx, gptHandler, indexes, userz, models, tiktokenHandler)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -8,7 +8,6 @@ openai:
 
 sys:
   secret_key: ""
-  extra_rate: 0.1
   init_user_credits: 0.1
 
 index_store:

--- a/config/config.go
+++ b/config/config.go
@@ -74,7 +74,6 @@ type DBConfig struct {
 }
 
 type System struct {
-	ExtraRate       float64 `yaml:"extra_rate"`
 	InitUserCredits float64 `yaml:"init_user_credits"`
 	SecretKey       string  `yaml:"secret_key"`
 }

--- a/service/user/user.go
+++ b/service/user/user.go
@@ -28,7 +28,6 @@ func New(
 }
 
 type Config struct {
-	ExtraRate       float64
 	InitUserCredits float64
 }
 
@@ -108,13 +107,9 @@ func (s *UserService) Topup(ctx context.Context, user *core.User, amount decimal
 func (s *UserService) ConsumeCreditsByModel(ctx context.Context, userID uint64, model core.Model, promptTokenCount, completionTokenCount int64) error {
 	log := logger.FromContext(ctx).WithField("service", "user.ConsumeCreditsByModel")
 	cost := model.CalculateTokenCost(promptTokenCount, completionTokenCount)
-	credits := cost
-	if s.cfg.ExtraRate > 0 {
-		credits = credits.Mul(decimal.NewFromFloat(1 + s.cfg.ExtraRate))
-	}
 	log.Printf("model: %s:%s, cost: $%s, token: %d->%d, credits: $%s\n", model.Provider, model.ProviderModel,
-		cost.StringFixed(8), promptTokenCount, completionTokenCount, credits.StringFixed(8))
-	return s.ConsumeCredits(ctx, userID, credits)
+		cost.StringFixed(8), promptTokenCount, completionTokenCount, cost.StringFixed(8))
+	return s.ConsumeCredits(ctx, userID, cost)
 }
 
 func (s *UserService) ConsumeCredits(ctx context.Context, userID uint64, amount decimal.Decimal) error {


### PR DESCRIPTION
Now we can customize the model price in the database, the `extra_rate` config is not used.