### PR TITLE
Feat/invoke bot from middleware

### DIFF
--- a/core/bot.go
+++ b/core/bot.go
@@ -49,9 +49,16 @@ type (
 		Required bool           `json:"required,omitempty"`
 	}
 
+	MiddlewareDesc interface {
+		Name() string
+		ValidateOptions(opts map[string]any) (any, error)
+		Process(ctx context.Context, opts any, turn *ConvTurn) (string, error)
+	}
+
 	MiddlewareService interface {
-		ProcessByConfig(ctx context.Context, m MiddlewareConfig, input string) MiddlewareResults
-		Process(ctx context.Context, m *Middleware, input string) *MiddlewareProcessResult
+		ProcessByConfig(ctx context.Context, m MiddlewareConfig, turn *ConvTurn) MiddlewareResults
+		Process(ctx context.Context, m *Middleware, turn *ConvTurn) *MiddlewareProcessResult
+		Register(ms ...MiddlewareDesc)
 	}
 )
 
@@ -161,7 +168,6 @@ type (
 )
 
 func (t *Bot) GetRequestContent(conv *Conversation, question string, additionData map[string]any) string {
-
 	var buf bytes.Buffer
 	data := map[string]interface{}{
 		"LangHint": conv.LangHint(),
@@ -221,7 +227,7 @@ func (t *Bot) GetChatMessages(conv *Conversation, additionData map[string]any) [
 	}
 
 	history := conv.History
-	if len(history) > conv.Bot.ContextTurnCount {
+	if len(history) > t.ContextTurnCount {
 		history = history[len(history)-conv.Bot.ContextTurnCount:]
 	}
 

--- a/core/bot.go
+++ b/core/bot.go
@@ -46,7 +46,7 @@ type (
 		Code     int            `json:"code"`
 		Result   string         `json:"result,omitempty"`
 		Err      string         `json:"err,omitempty"`
-		Required bool           `json:"required,omitempty"`
+		Required bool           `json:"-"`
 	}
 
 	MiddlewareDesc interface {

--- a/core/bot.go
+++ b/core/bot.go
@@ -45,7 +45,7 @@ type (
 		Name     string         `json:"name"`
 		Code     int            `json:"code"`
 		Result   string         `json:"result,omitempty"`
-		Err      error          `json:"err,omitempty"`
+		Err      string         `json:"err,omitempty"`
 		Required bool           `json:"required,omitempty"`
 	}
 

--- a/core/bot.go
+++ b/core/bot.go
@@ -19,6 +19,7 @@ const (
 	MiddlewareDuckduckgoSearch  = "duckduckgo-search"
 	MiddlewareIntentRecognition = "intent-recognition"
 	MiddlewareFetch             = "fetch"
+	MiddlewareBotastic          = "botastic"
 )
 
 const (

--- a/core/conv.go
+++ b/core/conv.go
@@ -61,8 +61,8 @@ const (
 )
 
 type TurnProcessError struct {
-	Code    int    `json:"code"`
-	Message string `json:"message"`
+	Code    int    `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
 }
 
 func (e *TurnProcessError) Scan(value interface{}) error {

--- a/core/conv.go
+++ b/core/conv.go
@@ -201,7 +201,7 @@ type (
 		// 	{{end}}
 		// WHERE
 		// 	"id"=@id
-		UpdateConvTurn(ctx context.Context, id uint64, response string, promptTokens, completionTokens, totalTokens int64, status int, mr MiddlewareResults, tpe *TurnProcessError) error
+		UpdateConvTurn(ctx context.Context, id uint64, response string, promptTokens, completionTokens, totalTokens int, status int, mr MiddlewareResults, tpe *TurnProcessError) error
 	}
 
 	ConversationService interface {

--- a/core/model.go
+++ b/core/model.go
@@ -87,9 +87,9 @@ func (m Model) Name() string {
 	return fmt.Sprintf("%s:%s", m.Provider, m.ProviderModel)
 }
 
-func (m Model) CalculateTokenCost(promptCount, completionCount int64) decimal.Decimal {
-	pc := decimal.NewFromInt(promptCount)
-	cc := decimal.NewFromInt(completionCount)
+func (m Model) CalculateTokenCost(promptCount, completionCount int) decimal.Decimal {
+	pc := decimal.NewFromInt(int64(promptCount))
+	cc := decimal.NewFromInt(int64(completionCount))
 
 	if m.PriceUSD.IsPositive() {
 		return m.PriceUSD.Mul(pc.Add(cc))

--- a/core/user.go
+++ b/core/user.go
@@ -97,7 +97,7 @@ type (
 		LoginWithTwitter(ctx context.Context, oauthToken, oauthVerifier, lang string) (*User, error)
 		Topup(ctx context.Context, user *User, amount decimal.Decimal) error
 		ConsumeCredits(ctx context.Context, userID uint64, amount decimal.Decimal) error
-		ConsumeCreditsByModel(ctx context.Context, userID uint64, model Model, promptTokenCount, completionTokenCount int64) error
+		ConsumeCreditsByModel(ctx context.Context, userID uint64, model Model, promptTokenCount, completionTokenCount int) error
 		ReplaceStore(store UserStore) UserService
 	}
 )

--- a/handler/conv/conv.go
+++ b/handler/conv/conv.go
@@ -39,7 +39,7 @@ type (
 
 		BotOverride core.BotOverride `json:"bot_override"`
 		Content     string           `json:"content"`
-		Timeout     time.Duration    `json:"timeout"`
+		Timeout     string           `json:"timeout"`
 	}
 )
 
@@ -257,8 +257,10 @@ func CreateOnewayConversation(convz core.ConversationService, convs core.Convers
 		}
 
 		timeout := 10 * time.Second
-		if body.Timeout > 0 {
-			timeout = body.Timeout
+		if body.Timeout != "" {
+			if nt, err := time.ParseDuration(body.Timeout); err == nil {
+				timeout = nt
+			}
 		}
 		ctx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()

--- a/handler/conv/conv.go
+++ b/handler/conv/conv.go
@@ -116,7 +116,7 @@ func GetConversationTurn(botz core.BotService, convs core.ConversationStore, hub
 			return
 		}
 
-		_, err = hub.AddAndWait(ctx, turnIDStr)
+		_, err = hub.AddAndWait(ctx, turnId)
 		if err != nil {
 			if err == context.Canceled {
 				render.Error(w, http.StatusBadRequest, err)
@@ -294,8 +294,7 @@ func CreateOnewayConversation(convz core.ConversationService, convs core.Convers
 			return
 		}
 
-		turnIDStr := strconv.FormatUint(turn.ID, 10)
-		_, err = hub.AddAndWait(ctx, turnIDStr)
+		_, err = hub.AddAndWait(ctx, turn.ID)
 		if err != nil {
 			if err == context.Canceled {
 				render.Error(w, http.StatusBadRequest, err)

--- a/internal/chanhub/chanhub.go
+++ b/internal/chanhub/chanhub.go
@@ -7,18 +7,18 @@ import (
 
 type Hub struct {
 	sync.Mutex
-	m map[string][]chan interface{}
+	m map[any][]chan any
 }
 
 func New() *Hub {
 	return &Hub{
-		m: make(map[string][]chan interface{}),
+		m: make(map[any][]chan any),
 	}
 }
 
-func (h *Hub) AddAndWait(ctx context.Context, key string) (interface{}, error) {
+func (h *Hub) AddAndWait(ctx context.Context, key any) (any, error) {
 	h.Lock()
-	ch := make(chan interface{})
+	ch := make(chan any)
 	defer close(ch)
 	h.m[key] = append(h.m[key], ch)
 	id := len(h.m[key]) - 1
@@ -34,7 +34,7 @@ func (h *Hub) AddAndWait(ctx context.Context, key string) (interface{}, error) {
 	}
 }
 
-func (h *Hub) deleteChan(key string, id int) {
+func (h *Hub) deleteChan(key any, id int) {
 	h.Lock()
 	defer h.Unlock()
 
@@ -52,7 +52,7 @@ func (h *Hub) deleteChan(key string, id int) {
 	h.m[key] = v
 }
 
-func (h *Hub) Broadcast(key string, result interface{}) {
+func (h *Hub) Broadcast(key any, result any) {
 	h.Lock()
 	defer h.Unlock()
 

--- a/service/bot/bot.go
+++ b/service/bot/bot.go
@@ -15,7 +15,6 @@ func New(
 	apps core.AppStore,
 	bots core.BotStore,
 	models core.ModelStore,
-	middlewarez core.MiddlewareService,
 ) *service {
 	botCache := cache.New(time.Minute*5, time.Minute*5)
 
@@ -26,7 +25,6 @@ func New(
 		apps:            apps,
 		bots:            bots,
 		models:          models,
-		middlewarez:     middlewarez,
 		botCache:        botCache,
 		conversationMap: conversationMap,
 	}
@@ -48,7 +46,7 @@ type (
 )
 
 func (s *service) ReplaceStore(bots core.BotStore) core.BotService {
-	return New(s.cfg, s.apps, bots, s.models, s.middlewarez)
+	return New(s.cfg, s.apps, bots, s.models)
 }
 
 func (s *service) GetBot(ctx context.Context, id uint64) (*core.Bot, error) {

--- a/service/index/index.go
+++ b/service/index/index.go
@@ -41,7 +41,7 @@ func (s *serviceImpl) createEmbeddingsWithLimit(ctx context.Context, req gogpt.E
 
 	resp, err := s.gptHandler.CreateEmbeddings(ctx, req)
 	if err == nil {
-		if err := s.userz.ConsumeCreditsByModel(ctx, userID, *m, int64(resp.Usage.PromptTokens), int64(resp.Usage.CompletionTokens)); err != nil {
+		if err := s.userz.ConsumeCreditsByModel(ctx, userID, *m, resp.Usage.PromptTokens, resp.Usage.CompletionTokens); err != nil {
 			log.Printf("ConsumeCredits error: %v\n", err)
 		}
 	}

--- a/service/middleware/botastic.go
+++ b/service/middleware/botastic.go
@@ -89,6 +89,9 @@ func (m *botastic) Process(ctx context.Context, opts any, turn *core.ConvTurn) (
 	if err := m.rotater.ProcessConvTurn(ctx, t); err != nil {
 		return "", err
 	}
+	if t.Error != nil {
+		return "", t.Error
+	}
 
 	return t.Response, nil
 }

--- a/service/middleware/botastic.go
+++ b/service/middleware/botastic.go
@@ -48,7 +48,7 @@ func (m *botastic) ValidateOptions(opts map[string]any) (any, error) {
 	if val, ok := opts["inherit"]; ok {
 		b, ok := val.(bool)
 		if !ok {
-			return nil, fmt.Errorf("inherit_conversation should be bool: %v", val)
+			return nil, fmt.Errorf("inherit should be bool: %v", val)
 		}
 		options.Inherit = b
 	}

--- a/service/middleware/botastic.go
+++ b/service/middleware/botastic.go
@@ -1,0 +1,70 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pandodao/botastic/core"
+	"github.com/pandodao/botastic/session"
+	"github.com/pandodao/botastic/worker/rotater"
+)
+
+type botastic struct {
+	rotater *rotater.Worker
+	bots    core.BotStore
+}
+
+type botasticOptions struct {
+	BotID uint64
+}
+
+func (m *botastic) Name() string {
+	return core.MiddlewareBotastic
+}
+
+func (m *botastic) ValidateOptions(opts map[string]any) (any, error) {
+	options := &botasticOptions{}
+
+	if val, ok := opts["bot_id"]; ok {
+		v, ok := val.(float64)
+		if !ok {
+			return nil, fmt.Errorf("bot_id is not a number: %v", val)
+		}
+
+		if v <= 0 || float64(int(v)) != v {
+			return nil, fmt.Errorf("bot_id is not a positive integer: %v", v)
+		}
+		options.BotID = uint64(v)
+	}
+
+	return options, nil
+}
+
+func (m *botastic) Process(ctx context.Context, opts any, input string) (string, error) {
+	options := opts.(*botasticOptions)
+	app := session.AppFrom(ctx)
+
+	// make sure bot is exist
+	bot, err := m.bots.GetBot(ctx, options.BotID)
+	if err != nil {
+		return "", fmt.Errorf("error when getting bot by bot_id: %d", options.BotID)
+	}
+
+	if bot.UserID != app.UserID {
+		return "", fmt.Errorf("bot_id not found: %d", options.BotID)
+	}
+
+	t := &core.ConvTurn{
+		BotID:        bot.ID,
+		AppID:        app.ID,
+		UserID:       app.UserID,
+		UserIdentity: "",
+		Request:      input,
+		Status:       core.ConvTurnStatusInit,
+	}
+	if err := m.rotater.ProcessConvTurn(ctx, t); err != nil {
+		return "", err
+	}
+
+	return t.Response, nil
+}

--- a/service/middleware/botastic_search.go
+++ b/service/middleware/botastic_search.go
@@ -19,6 +19,13 @@ type botasticSearchOptions struct {
 	AppID string
 }
 
+func InitBotasticSearch(apps core.AppStore, indexz core.IndexService) *botasticSearch {
+	return &botasticSearch{
+		apps:   apps,
+		indexz: indexz,
+	}
+}
+
 func (m *botasticSearch) Name() string {
 	return core.MiddlewareBotasticSearch
 }
@@ -52,7 +59,7 @@ func (m *botasticSearch) ValidateOptions(opts map[string]any) (any, error) {
 	return options, nil
 }
 
-func (m *botasticSearch) Process(ctx context.Context, opts any, input string) (string, error) {
+func (m *botasticSearch) Process(ctx context.Context, opts any, turn *core.ConvTurn) (string, error) {
 	options := opts.(*botasticSearchOptions)
 	app := session.AppFrom(ctx)
 	if options.AppID != "" {
@@ -67,7 +74,7 @@ func (m *botasticSearch) Process(ctx context.Context, opts any, input string) (s
 		ctx = session.WithApp(ctx, app)
 	}
 
-	searchResult, err := m.indexz.SearchIndex(ctx, app.UserID, input, options.Limit)
+	searchResult, err := m.indexz.SearchIndex(ctx, app.UserID, turn.Request, options.Limit)
 	if err != nil {
 		return "", err
 	}

--- a/service/middleware/ddg_search.go
+++ b/service/middleware/ddg_search.go
@@ -18,6 +18,10 @@ type duckDuckGoSearchOptions struct {
 	Limit int
 }
 
+func InitDuckduckgoSearch() *duckDuckGoSearch {
+	return &duckDuckGoSearch{}
+}
+
 func (m *duckDuckGoSearch) ValidateOptions(opts map[string]any) (any, error) {
 	options := &duckDuckGoSearchOptions{
 		Limit: 3,
@@ -38,9 +42,9 @@ func (m *duckDuckGoSearch) ValidateOptions(opts map[string]any) (any, error) {
 	return options, nil
 }
 
-func (m *duckDuckGoSearch) Process(ctx context.Context, opts any, input string) (string, error) {
+func (m *duckDuckGoSearch) Process(ctx context.Context, opts any, turn *core.ConvTurn) (string, error) {
 	options := opts.(*duckDuckGoSearchOptions)
-	r, err := ddg.WebSearch(ctx, input, options.Limit)
+	r, err := ddg.WebSearch(ctx, turn.Request, options.Limit)
 	if err != nil {
 		return "", err
 	}

--- a/service/middleware/fetch.go
+++ b/service/middleware/fetch.go
@@ -20,6 +20,10 @@ type fetchOptions struct {
 	URL string
 }
 
+func InitFetch() *fetch {
+	return &fetch{}
+}
+
 func (m *fetch) ValidateOptions(opts map[string]any) (any, error) {
 	options := &fetchOptions{}
 
@@ -40,7 +44,7 @@ func (m *fetch) ValidateOptions(opts map[string]any) (any, error) {
 	return options, nil
 }
 
-func (m *fetch) Process(ctx context.Context, opts any, input string) (string, error) {
+func (m *fetch) Process(ctx context.Context, opts any, turn *core.ConvTurn) (string, error) {
 	options := opts.(*fetchOptions)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, options.URL, nil)
 	if err != nil {

--- a/service/middleware/intent_recognition.go
+++ b/service/middleware/intent_recognition.go
@@ -14,6 +14,10 @@ type intentRecognitionOptions struct {
 	Intents []string
 }
 
+func InitIntentRecognition() *intentRecognition {
+	return &intentRecognition{}
+}
+
 func (m *intentRecognition) Name() string {
 	return core.MiddlewareIntentRecognition
 }
@@ -39,7 +43,7 @@ func (m *intentRecognition) ValidateOptions(opts map[string]any) (any, error) {
 	return options, nil
 }
 
-func (m *intentRecognition) Process(ctx context.Context, opts any, input string) (string, error) {
+func (m *intentRecognition) Process(ctx context.Context, opts any, turn *core.ConvTurn) (string, error) {
 	options := opts.(*intentRecognitionOptions)
 
 	prompt := `You will analyze the intent of the request.

--- a/service/middleware/middleware.go
+++ b/service/middleware/middleware.go
@@ -35,6 +35,7 @@ func New(
 		&duckDuckGoSearch{},
 		&intentRecognition{},
 		&fetch{},
+		&botastic{},
 	} {
 		middlewareMap[m.Name()] = m
 	}

--- a/service/middleware/middleware.go
+++ b/service/middleware/middleware.go
@@ -50,7 +50,7 @@ func (s *service) Process(ctx context.Context, m *core.Middleware, turn *core.Co
 		return &core.MiddlewareProcessResult{
 			Name:     m.Name,
 			Code:     core.MiddlewareProcessCodeInvalidOptions,
-			Err:      err,
+			Err:      err.Error(),
 			Required: true,
 		}
 	}
@@ -60,7 +60,7 @@ func (s *service) Process(ctx context.Context, m *core.Middleware, turn *core.Co
 		return &core.MiddlewareProcessResult{
 			Name:     m.Name,
 			Code:     core.MiddlewareProcessCodeUnknown,
-			Err:      errors.New("middleware not found"),
+			Err:      "middleware not found",
 			Required: gopts.Required,
 		}
 	}
@@ -70,7 +70,7 @@ func (s *service) Process(ctx context.Context, m *core.Middleware, turn *core.Co
 		return &core.MiddlewareProcessResult{
 			Name:     m.Name,
 			Code:     core.MiddlewareProcessCodeInvalidOptions,
-			Err:      err,
+			Err:      err.Error(),
 			Required: gopts.Required,
 		}
 	}
@@ -91,7 +91,7 @@ func (s *service) Process(ctx context.Context, m *core.Middleware, turn *core.Co
 		return &core.MiddlewareProcessResult{
 			Name:     m.Name,
 			Code:     code,
-			Err:      err,
+			Err:      err.Error(),
 			Required: gopts.Required,
 		}
 	}

--- a/service/middleware/middleware.go
+++ b/service/middleware/middleware.go
@@ -37,7 +37,7 @@ func (s *service) ProcessByConfig(ctx context.Context, mc core.MiddlewareConfig,
 	for _, m := range mc.Items {
 		result := s.Process(ctx, m, turn)
 		results = append(results, result)
-		if result.Required {
+		if result.Required && result.Code != 0 {
 			break
 		}
 	}

--- a/service/user/user.go
+++ b/service/user/user.go
@@ -181,7 +181,7 @@ func (s *UserService) Topup(ctx context.Context, user *core.User, amount decimal
 	return nil
 }
 
-func (s *UserService) ConsumeCreditsByModel(ctx context.Context, userID uint64, model core.Model, promptTokenCount, completionTokenCount int64) error {
+func (s *UserService) ConsumeCreditsByModel(ctx context.Context, userID uint64, model core.Model, promptTokenCount, completionTokenCount int) error {
 	log := logger.FromContext(ctx).WithField("service", "user.ConsumeCreditsByModel")
 	cost := model.CalculateTokenCost(promptTokenCount, completionTokenCount)
 	log.Printf("model: %s:%s, cost: $%s, token: %d->%d, credits: $%s\n", model.Provider, model.ProviderModel,

--- a/store/conv/dao/conv_turns.gen.go
+++ b/store/conv/dao/conv_turns.gen.go
@@ -160,7 +160,7 @@ type IConvTurnDo interface {
 	GetConvTurns(ctx context.Context, ids []uint64) (result []*core.ConvTurn, err error)
 	GetConvTurn(ctx context.Context, id uint64) (result *core.ConvTurn, err error)
 	GetConvTurnsByStatus(ctx context.Context, excludeIDs []uint64, status []int) (result []*core.ConvTurn, err error)
-	UpdateConvTurn(ctx context.Context, id uint64, response string, promptTokens int64, completionTokens int64, totalTokens int64, status int, mr core.MiddlewareResults, tpe *core.TurnProcessError) (err error)
+	UpdateConvTurn(ctx context.Context, id uint64, response string, promptTokens int, completionTokens int, totalTokens int, status int, mr core.MiddlewareResults, tpe *core.TurnProcessError) (err error)
 }
 
 // INSERT INTO "conversations"
@@ -354,7 +354,7 @@ func (c convTurnDo) GetConvTurnsByStatus(ctx context.Context, excludeIDs []uint6
 // WHERE
 //
 //	"id"=@id
-func (c convTurnDo) UpdateConvTurn(ctx context.Context, id uint64, response string, promptTokens int64, completionTokens int64, totalTokens int64, status int, mr core.MiddlewareResults, tpe *core.TurnProcessError) (err error) {
+func (c convTurnDo) UpdateConvTurn(ctx context.Context, id uint64, response string, promptTokens int, completionTokens int, totalTokens int, status int, mr core.MiddlewareResults, tpe *core.TurnProcessError) (err error) {
 	var params []interface{}
 
 	var generateSQL strings.Builder

--- a/store/conv/dao/conversations.gen.go
+++ b/store/conv/dao/conversations.gen.go
@@ -124,7 +124,7 @@ type IConversationDo interface {
 	GetConvTurns(ctx context.Context, ids []uint64) (result []*core.ConvTurn, err error)
 	GetConvTurn(ctx context.Context, id uint64) (result *core.ConvTurn, err error)
 	GetConvTurnsByStatus(ctx context.Context, excludeIDs []uint64, status []int) (result []*core.ConvTurn, err error)
-	UpdateConvTurn(ctx context.Context, id uint64, response string, promptTokens int64, completionTokens int64, totalTokens int64, status int, mr core.MiddlewareResults, tpe *core.TurnProcessError) (err error)
+	UpdateConvTurn(ctx context.Context, id uint64, response string, promptTokens int, completionTokens int, totalTokens int, status int, mr core.MiddlewareResults, tpe *core.TurnProcessError) (err error)
 }
 
 // INSERT INTO "conversations"
@@ -318,7 +318,7 @@ func (c conversationDo) GetConvTurnsByStatus(ctx context.Context, excludeIDs []u
 // WHERE
 //
 //	"id"=@id
-func (c conversationDo) UpdateConvTurn(ctx context.Context, id uint64, response string, promptTokens int64, completionTokens int64, totalTokens int64, status int, mr core.MiddlewareResults, tpe *core.TurnProcessError) (err error) {
+func (c conversationDo) UpdateConvTurn(ctx context.Context, id uint64, response string, promptTokens int, completionTokens int, totalTokens int, status int, mr core.MiddlewareResults, tpe *core.TurnProcessError) (err error) {
 	var params []interface{}
 
 	var generateSQL strings.Builder

--- a/store/migrations/20230424101926_add_error_to_conv_turn.sql
+++ b/store/migrations/20230424101926_add_error_to_conv_turn.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose StatementBegin
+SELECT 'up SQL query';
+ALTER TABLE conv_turns ADD COLUMN "error" jsonb DEFAULT '{}';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'down SQL query';
+ALTER TABLE conv_turns DROP COLUMN IF EXISTS "error";
+-- +goose StatementEnd

--- a/worker/rotater/rotater.go
+++ b/worker/rotater/rotater.go
@@ -206,8 +206,8 @@ func (w *Worker) ProcessConvTurn(ctx context.Context, turn *core.ConvTurn) error
 			ctx = session.WithApp(ctx, app)
 			middlewareResults = w.middlewarez.ProcessByConfig(ctx, middlewareCfg, turn)
 			lastResult := middlewareResults[len(middlewareResults)-1]
-			if lastResult.Err != nil && lastResult.Required {
-				return core.NewTurnProcessError(core.TurnProcessMiddlewareError, lastResult.Err)
+			if lastResult.Err != "" && lastResult.Required {
+				return core.NewTurnProcessError(core.TurnProcessMiddlewareError, errors.New(lastResult.Err))
 			}
 
 			middlewareOutputs := make([]string, 0)

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -2,8 +2,14 @@ package worker
 
 import (
 	"context"
+
+	"github.com/pandodao/botastic/core"
 )
 
 type Worker interface {
 	Run(ctx context.Context) error
+}
+
+type Rotater interface {
+	ProcessConvTurn(ctx context.Context, turn *core.ConvTurn) error
 }


### PR DESCRIPTION
Close #51 

* [x] Whether to migrate the database
* [ ] Whether to change the configuration
---

Add `botastic` middleware, it allows to call another bot in the middleware. The following is an example, if `inherit` is set to true, then it will inherit the conversation of the current bot.
```json
{
    "name": "botastic",
    "options": {
      "bot_id": 7,
      "inherit": false,
      "required": true
    }
}
```

The `botastic` middleware does not support nested calls, in a request, the maximum depth is 1 for `botastic` middleware.

---

Add the `error` field to `conv_turns` and no longer set the response if an error occurs. The following is an example,
```json
  "error": {
    "code": 1,
    "message": "required middleware error, code: 2, err: limit is not a number: x"
  }
```